### PR TITLE
fixed usage of internal package

### DIFF
--- a/module/module.go
+++ b/module/module.go
@@ -25,7 +25,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"cmd/go/internal/semver"
+	"marwan.io/vgop/semver"
 )
 
 // A Version is defined by a module path and version pair.


### PR DESCRIPTION
Tried to get https://github.com/marwan-at-work/mod tool but run into compiling error

```
❯ go get github.com/marwan-at-work/mod/cmd/mod
code/goroot/src/marwan.io/vgop/module/module.go:28:2: use of internal package cmd/go/internal/semver not allowed
```

this should fix this error